### PR TITLE
Add multi-label binary accuracy

### DIFF
--- a/kitt/image/classification/__init__.py
+++ b/kitt/image/classification/__init__.py
@@ -1,0 +1,6 @@
+from typing import Callable
+
+import numpy as np
+
+# (ground truth batch, prediction batch) -> metric batch/metric scalar
+TFMetric = Callable[[np.ndarray, np.ndarray], np.ndarray]

--- a/kitt/image/classification/metrics.py
+++ b/kitt/image/classification/metrics.py
@@ -1,0 +1,24 @@
+import tensorflow as tf
+from tensorflow.keras.metrics import binary_accuracy
+
+from . import TFMetric
+
+
+def multilabel_binary_accuracy_metric(threshold=0.5) -> TFMetric:
+    """
+    Creates a metric function that processes the output of a multi-label classification network
+    while treating it like a binary classification output.
+
+    If the value of any class in GT/prediction is larger or equal to `threshold`, the whole sample
+    will be considered to be positive. If not, it will be considered to be negative.
+    Binary accuracy is then used to evaluate these postprocessed positive/negative samples.
+    """
+
+    def multilabel_bin_acc(gt, prediction):
+        gt_any_true = tf.cast(tf.reduce_any(gt >= threshold, axis=1), tf.int32)
+        pred_any_true = tf.cast(
+            tf.reduce_any(prediction >= threshold, axis=1), tf.int32
+        )
+        return binary_accuracy(gt_any_true, pred_any_true)
+
+    return multilabel_bin_acc

--- a/tests/classification/test_metrics.py
+++ b/tests/classification/test_metrics.py
@@ -1,0 +1,66 @@
+import numpy as np
+
+from kitt.image.classification.metrics import multilabel_binary_accuracy_metric
+
+
+def test_multilabel_binary_accuracy_negative():
+    gt = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0],
+        ]
+    )
+    pred = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0],
+        ]
+    )
+    assert multilabel_binary_accuracy_metric(threshold=0.5)(gt, pred) == 1.0
+
+
+def test_multilabel_binary_accuracy_positive():
+    gt = np.array(
+        [
+            [0.0, 1.0, 0.0, 0.0],
+        ]
+    )
+    pred = np.array(
+        [
+            [0.0, 0.0, 1.0, 0.0],
+        ]
+    )
+    assert multilabel_binary_accuracy_metric(threshold=0.5)(gt, pred) == 1.0
+
+
+def test_multilabel_binary_accuracy_threshold():
+    gt = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.2],
+        ]
+    )
+    pred = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0],
+        ]
+    )
+    assert multilabel_binary_accuracy_metric(threshold=0.5)(gt, pred) == 1.0
+    assert multilabel_binary_accuracy_metric(threshold=0.1)(gt, pred) == 0.0
+
+
+def test_multilabel_binary_accuracy_complex():
+    gt = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.6],
+            [0.0, 0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0, 0.0],
+            [1.0, 0.5, 0.6, 1.0],
+        ]
+    )
+    pred = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+            [0.6, 0.0, 0.0, 1.0],
+        ]
+    )
+    assert multilabel_binary_accuracy_metric(threshold=0.5)(gt, pred) == 0.5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,4 +89,6 @@ def check_image_equality(image: np.ndarray, path: str, delta=0.01):
             return
         show_image_diff(reference, generated_image)
 
-        raise Exception(f"Image is not equal enough with reference at `{path}`, diff: {diff}")
+        raise Exception(
+            f"Image is not equal enough with reference at `{path}`, diff: {diff}"
+        )


### PR DESCRIPTION
This metric can be used to treat the output of a multi-label classification network as a binary classification.